### PR TITLE
Updated builder code with a simpler DSL pattern.

### DIFF
--- a/ruby/builder_instance_eval.rb
+++ b/ruby/builder_instance_eval.rb
@@ -1,73 +1,109 @@
-# I can't remember where I saw this trick, but it's neat
+
 # It looks more like markup than merely using a closure
 
 # Usage begins on line 59
 
-# Here's a builder for heirarchical data
+# A builder for heirarchical data 
 class HrBuilder
 
-    def initialize()
-        @school = School.new
-        @contact = ContactDetails.new
-    end
+  # The School this person attended
+  attr_reader :school
 
-    def contact_details(&blk)
-        @contact.instance_eval(&blk)
-    end
+  # The ContactDetails for this person
+  attr_reader :contact
 
-    def education(&blk)
-        @school.instance_eval(&blk)
-    end
+  # Initializes a new person with School and ContactDetails data. Provides a DSL for 
+  # easy input.
+  #
+  # Example:
+  #   builder = HrBuilder.new do
+  #     name "Gavin Morrice"
+  #     phone "+44 1234 567890"
+  #     school_name "Hard Knox"
+  #     graduated "2007"
+  #   end
+  #
+  def initialize(&builder)
+    @school  = School.new
+    @contact = ContactDetails.new
+    instance_eval(&builder)
+  end
 
-    # Serialize to lamest markup language ever
-    def to_sarcasm_ml()
-        <<TEMPLATE
-APPLICANT_NAME! #{@contact.person}
-PHONE_NUMBER! #{@contact.telephone}
-SCHOOL_NAME! #{@school.institution}
-GRAD_YEAR! #{@school.date}
-TEMPLATE
-    end
+  # Serialize to lamest markup language ever
+  def to_sarcasm_ml
+    <<-TEMPLATE
+      APPLICANT_NAME! #{contact.name}
+      PHONE_NUMBER!   #{contact.phone}
+      SCHOOL_NAME!    #{school.school_name}
+      GRAD_YEAR!      #{school.graduated}
+    TEMPLATE
+  end
 
+  # Forwards messages to child attributes if they are not recognised by self
+  def method_missing(method_name, *args, &block)
+    [school, contact].each do |child|
+      if child.respond_to?(method_name)
+        child.send(method_name, *args, &block) and return
+      end      
+    end
+    super
+  end
+  
 end
 
+
+# The College/University a Person attended
 class School
-    attr_accessor :institution, :date
 
-    def school_name(alamater)
-        @institution = alamater 
+  # A getter/setter method for this school's name. Sets the attribute if the param is
+  #   present, otherwise will return the stored value.
+  #
+  # Returns @school name as a String if set
+  def school_name(string = nil)
+    if string
+      @school_name = string
+    else
+      @school_name
     end
+  end
 
-    def graduated(year)
-        @date = year
+  def graduated(string = nil)
+    if string
+      @graduated = string
+    else
+      @graduated 
     end
+  end
 
 end
 
 class ContactDetails
-    attr_accessor :person, :telephone
 
-    def whole_name(name)
-        @person = name
+  def name(string = nil)
+    if string
+      @name = string
+    else
+      @name
     end
+  end
 
-    def phone(phone_number)
-        @telephone = phone_number
+  def phone(number = nil)
+    if number
+      @phone = number
+    else
+      @phone
     end
+  end
+  
 end
 
 # Usage
 
-builder = HrBuilder.new
-
-builder.contact_details do 
-    whole_name "Johnny Morrice"
-    phone "+44 1234 567890"
-end
-
-builder.education do
-    school_name "Edinburgh"
-    graduated "...."
+builder = HrBuilder.new do
+  name "Gavin Morrice"
+  phone "+44 1234 567890"
+  school_name "Hard Knox"
+  graduated "2007"
 end
 
 # Serialize to a modern, friendly format


### PR DESCRIPTION
Have a look at `method_missing` and how it's used here.

The getter/setter pattern is a nice one for keeping the method naming consistent too.

Documented using the [TomDoc documentation syntax](http://tomdoc.org)
